### PR TITLE
Fix spelling error of volunteer on the front page

### DIFF
--- a/app/views/frontpage/frontpage_site.html.erb
+++ b/app/views/frontpage/frontpage_site.html.erb
@@ -70,7 +70,7 @@
 
         <div class="col-md-12 norwegian-button no_padding">
           <a href="http://www.isfit.no/">
-            Become a voulenteer<br>
+            Become a volunteer<br>
             <small>Read more on the Norwegian site</small>
           </a>
         </div>


### PR DESCRIPTION
This change fixes a spelling error voulenteer -> volunteer on the front page of the English version.